### PR TITLE
bouton accueil vers calendrier et modif de style

### DIFF
--- a/components/events/timeline-single.js
+++ b/components/events/timeline-single.js
@@ -41,7 +41,7 @@ export default function TimelineSingle({ event, withYear }) {
       sx={{
         p: 2,
         my: 1,
-        backgroundColor: isFrenchMajorEvent ? "primary.lightest" : "neutral",
+        backgroundColor: "neutral",
         borderRadius: 2,
         transition: "all 0.2s ease-in-out",
       }}

--- a/pages/index.js
+++ b/pages/index.js
@@ -38,8 +38,8 @@ export default function HomePage({
         title="Roundnet France"
         subtitle="Le site officiel de la fédération française de roundnet"
         image="/images/home-slide.jpg"
-        mainButtonText="Découvrir"
-        mainButtonLink="#rules-demo"
+        mainButtonText="Le calendrier 2024"
+        mainButtonLink="/calendrier"
         altButtonText="Trouver un club"
         altButtonLink="/clubs-et-communautes/liste-des-clubs"
       />


### PR DESCRIPTION
Le bouton de la page d'accueil est changé pour rediriger vers le calendrier.
Le fond des tournois RF n'est plus bleu.